### PR TITLE
[PROPOSAL] use NSMenu instead of NSPopover;

### DIFF
--- a/TomatoBar/View.swift
+++ b/TomatoBar/View.swift
@@ -112,7 +112,6 @@ struct TBPopoverView: View {
         VStack(alignment: .leading, spacing: 8) {
             Button {
                 timer.startStop()
-                TBStatusItem.shared.closePopover(nil)
             } label: {
                 Text(timer.timer != nil ? (buttonHovered ? "Stop" : timer.timeLeftString) : "Start")
                     /*


### PR DESCRIPTION
**THIS PR IS A PROPOSAL.**

Hi @ivoronin as I was trying to fix the issue with the `NSPopover` getting _mispositioned_ I googled a bunch and came across this article in the human interface guidelines: https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras/ (Display a menu—not a popover—when the user clicks your menu bar extra.)

It seems that macOS doesn't like it when a `NSStatusItem` presents a `NSPopover` instead of a `NSMenu`. This PR is a proposal (and a prof of concept) to convert the `NSPopover` to a `NSMenu`. This is not the final product and is far from perfect but it works. 

When we use the `NSMenu` instead of `NSPopover` by default we get the standard behavior of of the `NSStatuBar` to not hide while the `NSMenu` is present. I also think this solves the issue with the frame not resizing. 

I wanted to get your opinion on it, as I don't want to waste our time here if this is not a viable solution.

**Demo Video:**
https://user-images.githubusercontent.com/28106084/170442090-c9037cc6-07e8-4e0a-89e7-45b7743b7f7d.mov
