### PR TITLE
Fix mispositioned popup arrow

### DIFF
--- a/TomatoBar/App.swift
+++ b/TomatoBar/App.swift
@@ -35,6 +35,9 @@ class TBStatusItem: NSObject, NSApplicationDelegate {
         popover.behavior = .transient
         popover.contentViewController = NSViewController()
         popover.contentViewController?.view = NSHostingView(rootView: view)
+		if let contentViewController = popover.contentViewController {
+			popover.contentSize = contentViewController.view.intrinsicContentSize
+		}
 
         statusBarItem = NSStatusBar.system.statusItem(
             withLength: NSStatusItem.variableLength


### PR DESCRIPTION
This fixes issue #23. I’ve only been able to test this on Ventura (13.1 22C5044e) however.