### PR TITLE
New FileHandle for each log write

### DIFF
--- a/TomatoBar/Log.swift
+++ b/TomatoBar/Log.swift
@@ -32,7 +32,6 @@ private let lineEnd = "\n".data(using: .utf8)!
 internal let logger = TBLogger()
 
 class TBLogger {
-    private var logHandle: FileHandle?
     private let encoder = JSONEncoder()
 
     init() {
@@ -40,7 +39,8 @@ class TBLogger {
         encoder.dateEncodingStrategy = .secondsSince1970
     }
     
-    func openFileHandle() {
+    func openFileHandle() -> FileHandle? {
+        let logHandle: FileHandle?
         let fileManager = FileManager.default
         let logPath = fileManager
             .urls(for: .cachesDirectory, in: .userDomainMask)
@@ -52,19 +52,21 @@ class TBLogger {
             guard fileManager.createFile(atPath: logPath, contents: nil) else {
                 print("cannot create log file")
                 logHandle = nil
-                return
+                return nil
             }
         }
 
         logHandle = FileHandle(forUpdatingAtPath: logPath)
         guard logHandle != nil else {
             print("cannot open log file")
-            return
+            return nil
         }
+
+        return logHandle
     }
 
     func append(event: TBLogEvent) {
-        openFileHandle()
+        let logHandle = openFileHandle()
         guard let logHandle = logHandle else {
             return
         }
@@ -74,7 +76,6 @@ class TBLogger {
             try logHandle.seekToEnd()
             try logHandle.write(contentsOf: jsonData + lineEnd)
             try logHandle.synchronize()
-            try logHandle.close()
         } catch {
             print("cannot write to log file: \(error)")
         }

--- a/TomatoBar/Log.swift
+++ b/TomatoBar/Log.swift
@@ -32,13 +32,15 @@ private let lineEnd = "\n".data(using: .utf8)!
 internal let logger = TBLogger()
 
 class TBLogger {
-    private let logHandle: FileHandle?
+    private var logHandle: FileHandle?
     private let encoder = JSONEncoder()
 
     init() {
         encoder.outputFormatting = .sortedKeys
         encoder.dateEncodingStrategy = .secondsSince1970
-
+    }
+    
+    func openFileHandle() {
         let fileManager = FileManager.default
         let logPath = fileManager
             .urls(for: .cachesDirectory, in: .userDomainMask)
@@ -62,14 +64,17 @@ class TBLogger {
     }
 
     func append(event: TBLogEvent) {
+        openFileHandle()
         guard let logHandle = logHandle else {
             return
         }
+        
         do {
             let jsonData = try encoder.encode(event)
             try logHandle.seekToEnd()
             try logHandle.write(contentsOf: jsonData + lineEnd)
             try logHandle.synchronize()
+            try logHandle.close()
         } catch {
             print("cannot write to log file: \(error)")
         }


### PR DESCRIPTION
This change covers a niche use case, and should not functionally alter the program in any way. It is a change to how the log file is written to, and how the operations interact with macOS system APIs.

The purpose is to generate FSEvents for each log write, so that writes will trigger a launchd agent that uses WatchPaths to run a program when the TomatoBar.log file is written to. I made this change so I could set up an agent to set the wallpaper color based on the state of TomatoBar, by monitoring the log file and reading the last line when it changes.

Currently, TomatoBar opens a FileHandle and maintains it for the duration of the program, using FileHandle.synchronize() to write to disk. However, this does not generate an FSEvent, and does not trigger the launchd agent. For that, the FileHandle needs to be closed, either with an explicit FileHandle.close(), or by the FileHandle object being deallocated.

I removed the logHandle property of TBLogger, and I moved the code for creating a FileHandle out of TBLogger's init() into a separate function, openFileHandle(), which returns the created FileHandle. append() calls openFileHandle(), does the append, and then when the function exits the FileHandle is deallocated, an FSEvent is generated, and the launchd agent will trigger. This process repeats each time the log is appended to.

I believe the performance impact of this change is negligible due to the infrequency of logging. I understand if you don't want to merge this change to cover this usage.