### PR TITLE
Fix empty window on app launch

### DIFF
--- a/TomatoBar/App.swift
+++ b/TomatoBar/App.swift
@@ -21,9 +21,7 @@ struct TBApp: App {
     }
 
     var body: some Scene {
-        Settings {
-            EmptyView()
-        }
+        Settings {}
     }
 }
 


### PR DESCRIPTION
This fixes https://github.com/ivoronin/TomatoBar/issues/89

`EmptyView()` now causes a window to be shown, we can simply remove it and leave `Settings{}` empty.