### PR TITLE
Add daily work total with persistence and localization

### DIFF
--- a/TomatoBar/App.swift
+++ b/TomatoBar/App.swift
@@ -28,10 +28,11 @@ struct TBApp: App {
 class TBStatusItem: NSObject, NSApplicationDelegate {
     private var popover = NSPopover()
     private var statusBarItem: NSStatusItem?
+    private let timer = TBTimer()
     static var shared: TBStatusItem!
 
     func applicationDidFinishLaunching(_: Notification) {
-        let view = TBPopoverView()
+        let view = TBPopoverView(timer: timer)
 
         popover.behavior = .transient
         popover.contentViewController = NSViewController()
@@ -65,10 +66,23 @@ class TBStatusItem: NSObject, NSApplicationDelegate {
     }
 
     func setIcon(name: NSImage.Name) {
-        statusBarItem?.button?.image = NSImage(named: name)
+        if let image = NSImage(named: name) {
+            /*
+             Menu bar icons should be template images to stay visible
+             in both light and dark appearances.
+             */
+            image.isTemplate = true
+            statusBarItem?.button?.image = image
+        } else {
+            statusBarItem?.button?.image = NSImage(
+                systemSymbolName: "timer",
+                accessibilityDescription: "TomatoBar"
+            )
+        }
     }
 
     func showPopover(_: AnyObject?) {
+        timer.updateTodayWorkTime()
         if let button = statusBarItem?.button {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
             popover.contentViewController?.view.window?.makeKey()

--- a/TomatoBar/Timer.swift
+++ b/TomatoBar/Timer.swift
@@ -18,6 +18,10 @@ class TBTimer: ObservableObject {
     private var notificationCenter = TBNotificationCenter()
     private var finishTime: Date!
     private var timerFormatter = DateComponentsFormatter()
+    @AppStorage("todayWorkSeconds") private var todayWorkSeconds: Double = 0
+    @AppStorage("todayWorkDate") private var todayWorkDate: String = ""
+    private var workStartTime: Date?
+    @Published var todayWorkTimeString: String = ""
     @Published var timeLeftString: String = ""
     @Published var timer: DispatchSourceTimer?
 
@@ -77,6 +81,13 @@ class TBTimer: ObservableObject {
 
         KeyboardShortcuts.onKeyUp(for: .startStopTimer, action: startStop)
         notificationCenter.setActionHandler(handler: onNotificationAction)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppWillTerminate),
+            name: NSApplication.willTerminateNotification,
+            object: nil
+        )
+        updateTodayWorkTime()
 
         let aem: NSAppleEventManager = NSAppleEventManager.shared()
         aem.setEventHandler(self,
@@ -109,6 +120,10 @@ class TBTimer: ObservableObject {
             print("url handling error: unknown command \(host)")
             return
         }
+    }
+
+    @objc private func handleAppWillTerminate() {
+        persistActiveWorkSession()
     }
 
     func startStop() {
@@ -148,6 +163,7 @@ class TBTimer: ObservableObject {
         /* Cannot publish updates from background thread */
         DispatchQueue.main.async { [self] in
             updateTimeLeft()
+            updateTodayWorkTime()
             let timeLeft = finishTime.timeIntervalSince(Date())
             if timeLeft <= 0 {
                 /*
@@ -176,6 +192,8 @@ class TBTimer: ObservableObject {
     }
 
     private func onWorkStart(context _: TBStateMachine.Context) {
+        checkDayReset()
+        workStartTime = Date()
         TBStatusItem.shared.setIcon(name: .work)
         player.playWindup()
         player.startTicking()
@@ -189,6 +207,8 @@ class TBTimer: ObservableObject {
 
     private func onWorkEnd(context _: TBStateMachine.Context) {
         player.stopTicking()
+        persistActiveWorkSession()
+        updateTodayWorkTime()
     }
 
     private func onRestStart(context _: TBStateMachine.Context) {
@@ -225,5 +245,55 @@ class TBTimer: ObservableObject {
         stopTimer()
         TBStatusItem.shared.setIcon(name: .idle)
         consecutiveWorkIntervals = 0
+    }
+
+    private func todayDateString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    private func checkDayReset() {
+        let today = todayDateString()
+        if todayWorkDate != today {
+            todayWorkSeconds = 0
+            todayWorkDate = today
+        }
+    }
+
+    private func persistActiveWorkSession() {
+        guard let start = workStartTime else {
+            return
+        }
+        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let effectiveStart = max(start, startOfToday)
+        todayWorkSeconds += Date().timeIntervalSince(effectiveStart)
+        workStartTime = nil
+    }
+
+    func updateTodayWorkTime() {
+        checkDayReset()
+        var totalSeconds = todayWorkSeconds
+        if let start = workStartTime {
+            let startOfToday = Calendar.current.startOfDay(for: Date())
+            let effectiveStart = max(start, startOfToday)
+            totalSeconds += Date().timeIntervalSince(effectiveStart)
+        }
+        let hours = Int(totalSeconds) / 3600
+        let minutes = (Int(totalSeconds) % 3600) / 60
+        if hours > 0 {
+            todayWorkTimeString = String.localizedStringWithFormat(
+                NSLocalizedString("TBTimer.todayWorkTime.hoursMinutes",
+                                  comment: "Today work time in hours and minutes"),
+                hours,
+                minutes
+            )
+        } else {
+            todayWorkTimeString = String.localizedStringWithFormat(
+                NSLocalizedString("TBTimer.todayWorkTime.minutes",
+                                  comment: "Today work time in minutes"),
+                minutes
+            )
+        }
     }
 }

--- a/TomatoBar/View.swift
+++ b/TomatoBar/View.swift
@@ -130,12 +130,16 @@ private enum ChildView {
 }
 
 struct TBPopoverView: View {
-    @ObservedObject var timer = TBTimer()
+    @ObservedObject var timer: TBTimer
     @State private var buttonHovered = false
     @State private var activeChildView = ChildView.intervals
 
     private var startLabel = NSLocalizedString("TBPopoverView.start.label", comment: "Start label")
     private var stopLabel = NSLocalizedString("TBPopoverView.stop.label", comment: "Stop label")
+
+    init(timer: TBTimer) {
+        self.timer = timer
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -184,6 +188,18 @@ struct TBPopoverView: View {
                 }
             }
 
+            GroupBox {
+                HStack {
+                    Text(NSLocalizedString("TBPopoverView.totalWorkToday.label",
+                                           comment: "Total work today label"))
+                    Spacer()
+                    Text(timer.todayWorkTimeString)
+                        .font(.system(.body).monospacedDigit())
+                        .bold()
+                }
+                .padding(4)
+            }
+
             Group {
                 Button {
                     NSApp.activate(ignoringOtherApps: true)
@@ -225,6 +241,9 @@ struct TBPopoverView: View {
             /* Use values from GeometryReader */
 //            .frame(width: 240, height: 276)
             .padding(12)
+            .onAppear {
+                timer.updateTodayWorkTime()
+            }
     }
 }
 

--- a/TomatoBar/en.lproj/Localizable.strings
+++ b/TomatoBar/en.lproj/Localizable.strings
@@ -17,8 +17,11 @@
 "TBPopoverView.intervals.label" = "Intervals";
 "TBPopoverView.settings.label" = "Settings";
 "TBPopoverView.sounds.label" = "Sounds";
+"TBPopoverView.totalWorkToday.label" = "Total work today:";
 "TBPopoverView.about.label" = "About";
 "TBPopoverView.quit.label" = "Quit";
+"TBTimer.todayWorkTime.hoursMinutes" = "%d h %d m";
+"TBTimer.todayWorkTime.minutes" = "%d m";
 "TBTimer.onRestStart.title" = "Time's up";
 "TBTimer.onRestStart.short.body" = "It's time for a short break!";
 "TBTimer.onRestStart.long.body" = "It's time for a long break!";

--- a/TomatoBar/ko.lproj/Localizable.strings
+++ b/TomatoBar/ko.lproj/Localizable.strings
@@ -17,8 +17,11 @@
 "TBPopoverView.intervals.label" = "간격";
 "TBPopoverView.settings.label" = "설정";
 "TBPopoverView.sounds.label" = "사운드";
+"TBPopoverView.totalWorkToday.label" = "오늘 총 작업 시간:";
 "TBPopoverView.about.label" = "앱 정보";
 "TBPopoverView.quit.label" = "종료";
+"TBTimer.todayWorkTime.hoursMinutes" = "%d시간 %d분";
+"TBTimer.todayWorkTime.minutes" = "%d분";
 "TBTimer.onRestStart.title" = "시간 종료";
 "TBTimer.onRestStart.short.body" = "짧은 휴식을 취할 시간입니다!";
 "TBTimer.onRestStart.long.body" = "긴 휴식을 취할 시간입니다!";

--- a/TomatoBar/zh-Hans.lproj/Localizable.strings
+++ b/TomatoBar/zh-Hans.lproj/Localizable.strings
@@ -17,8 +17,11 @@
 "TBPopoverView.intervals.label" = "时长";
 "TBPopoverView.settings.label" = "设置";
 "TBPopoverView.sounds.label" = "声音";
+"TBPopoverView.totalWorkToday.label" = "今日总工作时间：";
 "TBPopoverView.about.label" = "关于";
 "TBPopoverView.quit.label" = "退出";
+"TBTimer.todayWorkTime.hoursMinutes" = "%d小时 %d分";
+"TBTimer.todayWorkTime.minutes" = "%d分";
 "TBTimer.onRestStart.title" = "时间到";
 "TBTimer.onRestStart.short.body" = "小憩时间到!";
 "TBTimer.onRestStart.long.body" = "长休息时间到!";


### PR DESCRIPTION
## Summary

Add a daily work total to the popover.

## What changed

- track total work time for the current day
- reset the counter when the day changes
- persist in-progress work time on app termination
- pass a shared `TBTimer` into `TBPopoverView`
- mark status bar icons as template images
- use an SF Symbol fallback if icon assets are missing
- localize the new UI for English, Korean, and Simplified Chinese

## Why

This keeps the new daily total accurate, avoids losing active-session time on quit, and keeps the new UI consistent with the app's existing localization support.
