### PR TITLE
docs: remove leading $ from brew install commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ TomatoBar is fully sandboxed with no entitlements.
 
 Download the latest release <a href="https://github.com/ivoronin/TomatoBar/releases/latest/">here</a> or install using Homebrew:
 ```
-$ brew install --cask tomatobar
+brew install --cask tomatobar
 ```
 
 If the app doesn't start, install using the `--no-quarantine` flag:
 ```
-$ brew install --cask --no-quarantine tomatobar
+brew install --cask --no-quarantine tomatobar
 ```
 
 ## Integration with other tools


### PR DESCRIPTION
Removed `$` from `brew` commands since it is annoying while copy pasting the commands to terminal.

Hope it helps 

This small change can significantly improve the onboarding experience for new users who aren't familiar with shell conventions.