### PR TITLE
feat: add time tracking

### DIFF
--- a/TomatoBar.xcodeproj/project.pbxproj
+++ b/TomatoBar.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		8AA5B3EB281295DB00BE1A6C /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 8AA5B3EA281295DB00BE1A6C /* KeyboardShortcuts */; };
 		8AA5B3F22812A74600BE1A6C /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA5B3F12812A74600BE1A6C /* Notifications.swift */; };
 		8AEE49AF2AA75A5E00243D2F /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE49AE2AA75A5E00243D2F /* Log.swift */; };
+		8AEE49B02AA75A5E00243D30 /* Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEE49B12AA75A5E00243D31 /* Stats.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +34,7 @@
 		8AA54346293094AB002A47FC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8AA5B3F12812A74600BE1A6C /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		8AEE49AE2AA75A5E00243D2F /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		8AEE49B12AA75A5E00243D31 /* Stats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stats.swift; sourceTree = "<group>"; };
 		C4C8DE0E2930DBB4003B1110 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		4CC11A472B6A28500012E8EC /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -73,6 +75,7 @@
 			children = (
 				8A21B78B27EE31A20009E5DB /* App.swift */,
 				8AEE49AE2AA75A5E00243D2F /* Log.swift */,
+				8AEE49B12AA75A5E00243D31 /* Stats.swift */,
 				8A21B78D27EE31A20009E5DB /* View.swift */,
 				8A9F700827EE396E0012A1EC /* State.swift */,
 				8A9F701827EE3DAF0012A1EC /* Timer.swift */,
@@ -199,6 +202,7 @@
 			files = (
 				8A9F701F27EE536D0012A1EC /* Player.swift in Sources */,
 				8AEE49AF2AA75A5E00243D2F /* Log.swift in Sources */,
+				8AEE49B02AA75A5E00243D30 /* Stats.swift in Sources */,
 				8A21B78E27EE31A20009E5DB /* View.swift in Sources */,
 				8A9F701927EE3DAF0012A1EC /* Timer.swift in Sources */,
 				8A21B78C27EE31A20009E5DB /* App.swift in Sources */,

--- a/TomatoBar/Stats.swift
+++ b/TomatoBar/Stats.swift
@@ -1,0 +1,227 @@
+import Foundation
+import SwiftUI
+
+/*
+ * Read-only stats layer.
+ *
+ * It reconstructs work/rest intervals by replaying the transition events that
+ * TBLogger (Log.swift) already appends to TomatoBar.log - the timer and the
+ * state machine are never touched. Intervals are paired from state
+ * transitions, split at local midnight and aggregated per day.
+ */
+
+/* Minimal decodable view of a single TBLogEventTransition line.
+ * Other event types (e.g. "appstart") decode too but are filtered by `type`. */
+private struct TBRawEvent: Decodable {
+    let type: String
+    let timestamp: Date
+    let fromState: String?
+    let toState: String?
+}
+
+enum TBIntervalKind {
+    case work, shortRest, longRest
+}
+
+struct TBInterval: Identifiable {
+    let id = UUID()
+    let kind: TBIntervalKind
+    let start: Date
+    let end: Date
+    /* No closing transition was found (timer still running or app crashed). */
+    let isOpenEnded: Bool
+    /* Set during the midnight split for the boundary segments. */
+    let continuesFromPrevDay: Bool
+    let continuesToNextDay: Bool
+
+    var duration: TimeInterval { end.timeIntervalSince(start) }
+}
+
+struct TBDaySummary: Identifiable {
+    var id: Date { day }
+    let day: Date // start of day, local time
+    let workSeconds: TimeInterval
+    let shortRestSeconds: TimeInterval
+    let longRestSeconds: TimeInterval
+    let intervals: [TBInterval] // ordered by start, already day-local
+}
+
+enum TBStatsParser {
+    /* Same caches-dir resolution as TBLogger in Log.swift (source of truth).
+     * Under the App Sandbox this is the container path, not ~/Library/Caches,
+     * so it must match exactly to read the file the logger writes.
+     * `logFileName` is private in Log.swift, hence the repeated literal. */
+    static var logFileURL: URL? {
+        FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("TomatoBar.log")
+    }
+
+    struct ParseResult {
+        let days: [TBDaySummary]
+        let fileMissing: Bool
+        let readFailed: Bool
+    }
+
+    static func parse(workLen: Int, shortLen: Int, longLen: Int,
+                      now: Date = Date(),
+                      calendar: Calendar = .current) -> ParseResult {
+        guard let url = logFileURL else {
+            return ParseResult(days: [], fileMissing: true, readFailed: false)
+        }
+        if !FileManager.default.fileExists(atPath: url.path) {
+            return ParseResult(days: [], fileMissing: true, readFailed: false)
+        }
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            return ParseResult(days: [], fileMissing: false, readFailed: true)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970 // mirrors TBLogger
+
+        var transitions: [TBRawEvent] = []
+        for line in contents.split(separator: "\n") {
+            /* Decode each line independently so a partial trailing line
+             * (crash mid-write) or any bad line is skipped, not fatal. */
+            guard let data = line.data(using: .utf8),
+                  let event = try? decoder.decode(TBRawEvent.self, from: data),
+                  event.type == "transition" else { continue }
+            transitions.append(event)
+        }
+        transitions.sort { $0.timestamp < $1.timestamp }
+
+        let intervals = reconstruct(transitions: transitions,
+                                    workLen: workLen, shortLen: shortLen,
+                                    longLen: longLen, now: now)
+        let split = intervals.flatMap { splitAtMidnight($0, calendar: calendar) }
+        let days = aggregate(split, calendar: calendar)
+        return ParseResult(days: days, fileMissing: false, readFailed: false)
+    }
+
+    /* Forward pass: any new toState transition closes the interval that was
+     * open (its fromState), implementing "pair with the next fromState==…". */
+    private static func reconstruct(transitions: [TBRawEvent],
+                                    workLen: Int, shortLen: Int, longLen: Int,
+                                    now: Date) -> [TBInterval] {
+        var result: [TBInterval] = []
+        var openState: String? // "work" or "rest"
+        var openStart: Date?
+
+        func close(at end: Date, openEnded: Bool) {
+            guard let state = openState, let start = openStart, end > start else {
+                openState = nil; openStart = nil; return
+            }
+            let kind = classify(state: state, duration: end.timeIntervalSince(start),
+                                shortLen: shortLen, longLen: longLen)
+            result.append(TBInterval(kind: kind, start: start, end: end,
+                                     isOpenEnded: openEnded,
+                                     continuesFromPrevDay: false,
+                                     continuesToNextDay: false))
+            openState = nil; openStart = nil
+        }
+
+        for t in transitions {
+            guard let to = t.toState else { continue }
+            close(at: t.timestamp, openEnded: false)
+            if to == "work" || to == "rest" {
+                openState = to
+                openStart = t.timestamp
+            }
+        }
+
+        /* Unclosed trailing interval: cap so a quit-without-stop or crash
+         * cannot produce a runaway multi-day bar. */
+        if let state = openState, let start = openStart {
+            let len = state == "work" ? workLen : longLen
+            let cap = start.addingTimeInterval(TimeInterval(len * 60 + 90))
+            close(at: min(now, cap), openEnded: true)
+        }
+        return result
+    }
+
+    private static func classify(state: String, duration: TimeInterval,
+                                 shortLen: Int, longLen: Int) -> TBIntervalKind {
+        guard state == "rest" else { return .work }
+        let dShort = abs(duration - Double(shortLen * 60))
+        let dLong = abs(duration - Double(longLen * 60))
+        return dShort <= dLong ? .shortRest : .longRest
+    }
+
+    /* Expand an interval into day-local segments at local midnight. */
+    private static func splitAtMidnight(_ iv: TBInterval,
+                                        calendar: Calendar) -> [TBInterval] {
+        var segments: [TBInterval] = []
+        var cursor = iv.start
+        while cursor < iv.end {
+            let dayStart = calendar.startOfDay(for: cursor)
+            let nextMidnight = calendar.date(byAdding: .day, value: 1,
+                                             to: dayStart) ?? iv.end
+            let segEnd = min(nextMidnight, iv.end)
+            let fromPrev = cursor != iv.start
+            let toNext = segEnd != iv.end
+            segments.append(TBInterval(
+                kind: iv.kind, start: cursor, end: segEnd,
+                isOpenEnded: iv.isOpenEnded && !toNext,
+                continuesFromPrevDay: fromPrev,
+                continuesToNextDay: toNext))
+            cursor = segEnd
+        }
+        return segments
+    }
+
+    private static func aggregate(_ intervals: [TBInterval],
+                                  calendar: Calendar) -> [TBDaySummary] {
+        let grouped = Dictionary(grouping: intervals) {
+            calendar.startOfDay(for: $0.start)
+        }
+        return grouped.map { day, ivs in
+            let sorted = ivs.sorted { $0.start < $1.start }
+            var work = 0.0, short = 0.0, long = 0.0
+            for iv in sorted {
+                switch iv.kind {
+                case .work: work += iv.duration
+                case .shortRest: short += iv.duration
+                case .longRest: long += iv.duration
+                }
+            }
+            return TBDaySummary(day: day, workSeconds: work,
+                                shortRestSeconds: short, longRestSeconds: long,
+                                intervals: sorted)
+        }
+        .sorted { $0.day > $1.day }
+    }
+}
+
+final class TBStatsStore: ObservableObject {
+    @Published var days: [TBDaySummary] = []
+    @Published var isLoading = false
+    @Published var loadError = false
+
+    func load(workLen: Int, shortLen: Int, longLen: Int) {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = TBStatsParser.parse(workLen: workLen,
+                                             shortLen: shortLen,
+                                             longLen: longLen)
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.days = result.days
+                self.loadError = result.readFailed
+                self.isLoading = false
+            }
+        }
+    }
+
+    func summary(for date: Date, calendar: Calendar = .current) -> TBDaySummary {
+        let day = calendar.startOfDay(for: date)
+        return days.first { $0.day == day }
+            ?? TBDaySummary(day: day, workSeconds: 0, shortRestSeconds: 0,
+                            longRestSeconds: 0, intervals: [])
+    }
+
+    /* Most recent days that have any activity, newest first. */
+    func recentDays(_ count: Int) -> [TBDaySummary] {
+        Array(days.prefix(count))
+    }
+}

--- a/TomatoBar/View.swift
+++ b/TomatoBar/View.swift
@@ -125,8 +125,247 @@ private struct SoundsView: View {
     }
 }
 
+private func tbColor(_ kind: TBIntervalKind) -> Color {
+    switch kind {
+    case .work: return .accentColor
+    case .shortRest: return .blue
+    case .longRest: return .orange
+    }
+}
+
+private func tbKindLabel(_ kind: TBIntervalKind) -> String {
+    switch kind {
+    case .work:
+        return NSLocalizedString("StatsView.work.label", comment: "Work")
+    case .shortRest:
+        return NSLocalizedString("StatsView.shortRest.label", comment: "Short break")
+    case .longRest:
+        return NSLocalizedString("StatsView.longRest.label", comment: "Long break")
+    }
+}
+
+private let tbHMFormatter: DateComponentsFormatter = {
+    let f = DateComponentsFormatter()
+    f.unitsStyle = .abbreviated
+    f.allowedUnits = [.hour, .minute]
+    return f
+}()
+
+private func tbFormatHM(_ seconds: TimeInterval) -> String {
+    if seconds < 60 { return "0m" }
+    return tbHMFormatter.string(from: seconds) ?? "0m"
+}
+
+private let tbClockFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.timeStyle = .short
+    f.dateStyle = .none
+    return f
+}()
+
+private let tbDayFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.setLocalizedDateFormatFromTemplate("MMMd")
+    return f
+}()
+
+/* Anything under a minute is treated as "no data" so a just-started or
+ * idle day renders as an empty track instead of a full bar. */
+private let tbMinTracked: TimeInterval = 60
+private let tbTrackColor = Color.primary.opacity(0.08)
+private let tbBarRadius: CGFloat = 3
+
+/* Stacked colored bar over a faint track. The overall fill width is scaled
+ * by `scaleMax` (the busiest recent day) so short days look short and the
+ * longest day fills the bar - they are never normalised to themselves. */
+private struct TBBar: View {
+    /* (color, seconds) in draw order. */
+    let segments: [(Color, TimeInterval)]
+    let scaleMax: TimeInterval
+
+    var body: some View {
+        let total = segments.reduce(0) { $0 + $1.1 }
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: tbBarRadius).fill(tbTrackColor)
+                if total >= tbMinTracked, scaleMax >= tbMinTracked {
+                    let fillW = geo.size.width
+                        * CGFloat(min(1, total / scaleMax))
+                    HStack(spacing: 0) {
+                        ForEach(Array(segments.enumerated()), id: \.offset) { _, s in
+                            Rectangle().fill(s.0)
+                                .frame(width: total > 0
+                                       ? fillW * CGFloat(s.1 / total) : 0)
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: tbBarRadius))
+                }
+            }
+        }
+    }
+}
+
+private struct TBRecentRow: View {
+    let summary: TBDaySummary
+    let scaleMax: TimeInterval
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(tbDayFormatter.string(from: summary.day))
+                .font(.caption.monospacedDigit())
+                .foregroundColor(isSelected ? .primary : .secondary)
+                .frame(width: 46, alignment: .leading)
+            TBBar(segments: [(.accentColor, summary.workSeconds)],
+                  scaleMax: scaleMax)
+                .frame(height: 6)
+            Text(tbFormatHM(summary.workSeconds))
+                .font(.caption.monospacedDigit())
+                .foregroundColor(summary.workSeconds >= tbMinTracked
+                                 ? .primary : .secondary)
+                .frame(width: 48, alignment: .trailing)
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isSelected ? Color.accentColor.opacity(0.14) : .clear)
+        )
+        .contentShape(Rectangle())
+    }
+}
+
+private struct StatsView: View {
+    @EnvironmentObject var timer: TBTimer
+    @StateObject private var store = TBStatsStore()
+    @State private var selectedDate = Date()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            DatePicker("", selection: $selectedDate,
+                       in: ...Date(), displayedComponents: .date)
+                .datePickerStyle(.field)
+                .labelsHidden()
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if store.loadError {
+                placeholder("StatsView.error.label")
+            } else if store.days.isEmpty {
+                placeholder("StatsView.empty.label")
+            } else {
+                content
+            }
+
+            Spacer().frame(minHeight: 0)
+        }
+        .padding(6)
+        .onAppear {
+            store.load(workLen: timer.workIntervalLength,
+                       shortLen: timer.shortRestIntervalLength,
+                       longLen: timer.longRestIntervalLength)
+        }
+    }
+
+    private func placeholder(_ key: String) -> some View {
+        VStack {
+            Spacer()
+            Text(NSLocalizedString(key, comment: ""))
+                .font(.caption).foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        let recent = store.recentDays(7)
+        let scaleMax = recent
+            .map { $0.workSeconds + $0.shortRestSeconds + $0.longRestSeconds }
+            .max() ?? 0
+        let workScale = recent.map(\.workSeconds).max() ?? 0
+        let summary = store.summary(for: selectedDate)
+        let selectedDay = Calendar.current.startOfDay(for: selectedDate)
+
+        // Selected day summary
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(NSLocalizedString("StatsView.worked.label",
+                                       comment: "Worked"))
+                    .font(.caption).foregroundColor(.secondary)
+                Spacer()
+                Text(tbFormatHM(summary.workSeconds))
+                    .font(.system(.title3).monospacedDigit())
+            }
+            TBBar(segments: [(.accentColor, summary.workSeconds),
+                             (.blue, summary.shortRestSeconds),
+                             (.orange, summary.longRestSeconds)],
+                  scaleMax: scaleMax)
+                .frame(height: 7)
+        }
+
+        if summary.intervals.isEmpty {
+            Text(NSLocalizedString("StatsView.noData.label",
+                                   comment: "No activity"))
+                .font(.caption).foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(summary.intervals) { iv in
+                        intervalRow(iv)
+                    }
+                }
+                .padding(.trailing, 2)
+            }
+            .frame(maxHeight: 90)
+        }
+
+        Divider()
+
+        Text(NSLocalizedString("StatsView.recent.label",
+                               comment: "Recent days"))
+            .font(.caption).foregroundColor(.secondary)
+        VStack(spacing: 1) {
+            ForEach(recent) { day in
+                TBRecentRow(summary: day, scaleMax: workScale,
+                            isSelected: day.day == selectedDay)
+                    .onTapGesture { selectedDate = day.day }
+            }
+        }
+    }
+
+    private func intervalRow(_ iv: TBInterval) -> some View {
+        HStack(spacing: 6) {
+            Circle().fill(tbColor(iv.kind)).frame(width: 6, height: 6)
+            Text(tbClockFormatter.string(from: iv.start)
+                 + " – "
+                 + (iv.continuesToNextDay ? "00:00"
+                    : tbClockFormatter.string(from: iv.end)))
+                .font(.caption.monospacedDigit())
+                .fixedSize()
+            Text(tbKindLabel(iv.kind))
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer(minLength: 4)
+            if iv.continuesFromPrevDay {
+                Text("↰").font(.caption2).foregroundColor(.secondary)
+            }
+            if iv.continuesToNextDay {
+                Text("↴").font(.caption2).foregroundColor(.secondary)
+            }
+            if iv.isOpenEnded {
+                Text("…").font(.caption2).foregroundColor(.secondary)
+            }
+            Text(tbFormatHM(iv.duration))
+                .font(.caption.monospacedDigit())
+                .foregroundColor(.secondary)
+                .frame(width: 42, alignment: .trailing)
+        }
+    }
+}
+
 private enum ChildView {
-    case intervals, settings, sounds
+    case intervals, settings, sounds, stats
 }
 
 struct TBPopoverView: View {
@@ -168,6 +407,8 @@ struct TBPopoverView: View {
                                        comment: "Settings label")).tag(ChildView.settings)
                 Text(NSLocalizedString("TBPopoverView.sounds.label",
                                        comment: "Sounds label")).tag(ChildView.sounds)
+                Text(NSLocalizedString("TBPopoverView.stats.label",
+                                       comment: "Stats label")).tag(ChildView.stats)
             }
             .labelsHidden()
             .frame(maxWidth: .infinity)
@@ -181,6 +422,8 @@ struct TBPopoverView: View {
                     SettingsView().environmentObject(timer)
                 case .sounds:
                     SoundsView().environmentObject(timer.player)
+                case .stats:
+                    StatsView().environmentObject(timer)
                 }
             }
 

--- a/TomatoBar/en.lproj/Localizable.strings
+++ b/TomatoBar/en.lproj/Localizable.strings
@@ -25,3 +25,12 @@
 "TBTimer.onRestStart.skip.title" = "Skip";
 "TBTimer.onRestFinish.title" = "Break is over";
 "TBTimer.onRestFinish.body" = "Keep up the good work!";
+"TBPopoverView.stats.label" = "Stats";
+"StatsView.worked.label" = "Worked";
+"StatsView.recent.label" = "Recent days";
+"StatsView.empty.label" = "No tracked sessions yet";
+"StatsView.error.label" = "Cannot read history";
+"StatsView.noData.label" = "No activity";
+"StatsView.work.label" = "Work";
+"StatsView.shortRest.label" = "Short break";
+"StatsView.longRest.label" = "Long break";

--- a/TomatoBar/ko.lproj/Localizable.strings
+++ b/TomatoBar/ko.lproj/Localizable.strings
@@ -25,3 +25,12 @@
 "TBTimer.onRestStart.skip.title" = "건너뛰기";
 "TBTimer.onRestFinish.title" = "휴식 시간 종료";
 "TBTimer.onRestFinish.body" = "다시 작업을 시작하세요!";
+"TBPopoverView.stats.label" = "통계";
+"StatsView.worked.label" = "작업함";
+"StatsView.recent.label" = "최근 날짜";
+"StatsView.empty.label" = "아직 기록된 세션이 없습니다";
+"StatsView.error.label" = "기록을 읽을 수 없습니다";
+"StatsView.noData.label" = "활동 없음";
+"StatsView.work.label" = "작업";
+"StatsView.shortRest.label" = "짧은 휴식";
+"StatsView.longRest.label" = "긴 휴식";

--- a/TomatoBar/zh-Hans.lproj/Localizable.strings
+++ b/TomatoBar/zh-Hans.lproj/Localizable.strings
@@ -25,3 +25,12 @@
 "TBTimer.onRestStart.skip.title" = "跳过";
 "TBTimer.onRestFinish.title" = "休息结束";
 "TBTimer.onRestFinish.body" = "继续努力!";
+"TBPopoverView.stats.label" = "统计";
+"StatsView.worked.label" = "已工作";
+"StatsView.recent.label" = "最近几天";
+"StatsView.empty.label" = "暂无记录的会话";
+"StatsView.error.label" = "无法读取历史记录";
+"StatsView.noData.label" = "无活动";
+"StatsView.work.label" = "工作";
+"StatsView.shortRest.label" = "小憩";
+"StatsView.longRest.label" = "长休息";


### PR DESCRIPTION
## Summary (described by Claude, soryy :) )

  Adds a fourth tab, **Stats**, that lets you look back at how much you've
  worked. Pick a day to see the total time worked, a proportional
  work/break bar, an ordered timeline of every interval with clock times,
  and a "Recent days" strip comparing the last 7 days at a glance.

  ## Why

  TomatoBar already records every state transition to `TomatoBar.log`, but
  there was no way to review past activity in the app. This surfaces that
  data without any new storage or dependencies.

  ## Approach

  The feature is **purely additive and read-only**:

  - No changes to `Timer.swift` or the state machine.
  - Sessions are reconstructed by parsing the existing
    `TomatoBar.log` transition events (same caches-dir path and
    `.secondsSince1970` encoding as `TBLogger`), so it works
    **retroactively** on logs from previous versions.
  - Work/rest intervals are paired from `toState`/`fromState` transitions;
    a rest is classified short vs long by nearest match to the configured
    break lengths.
  - No new third-party dependencies; Swift Charts is intentionally avoided
    (it requires macOS 13; the deployment target stays at 12.3). The
    visualisations are plain SwiftUI.

  New file `Stats.swift` holds the model, parser and an `ObservableObject`
  store (parsing runs off the main thread). `View.swift` gets the new
  `ChildView` case, picker entry, and the `StatsView` UI, following the
  existing tab conventions (`GroupBox`, `@EnvironmentObject`, monospaced
  digits, `NSLocalizedString`).

  ## Edge cases handled

  - **Midnight-crossing intervals** (e.g. 23:50–00:10) are split at local
    midnight, attributed to each day, and marked with `↰` / `↴`.
  - **Unclosed/crashed intervals** (no closing transition) are capped and
    marked `…` (in progress) so they can't produce a runaway multi-day bar.
  - **Missing / empty / partially written log** degrades to a friendly
    empty or error state; bad lines are skipped, not fatal.
  - **DST-safe** day boundaries via `Calendar.startOfDay`.
  - Bars are scaled against the busiest recent day with a sub-minute
    threshold, so a freshly started or idle day shows an empty track
    instead of a full bar.

  ## Localisation

  New keys added to all three localisations: `en`, `ko`, `zh-Hans`.

  ## Testing

  - Builds clean (Release, macOS 12.3 target, no new warnings).
  - Verified live: work/short/long cycles produce correct totals,
    ordered timeline, and correct short/long classification.
  - Empty-log and just-started states verified.
  - Midnight split verified by temporarily setting the system clock across
    00:00 during a work interval.

  ## Screenshots

<img width="309" height="325" alt="Screenshot 2026-05-17 at 5 30 58 PM" src="https://github.com/user-attachments/assets/3e6b33e3-09ec-46f7-9ff7-8ed654e66d49" />

  ## Notes

  - The popover height is fixed from the Intervals tab and `NSPopover`
    doesn't resize per tab (existing documented limitation), so the day
    picker uses the compact `.field` style and the "Recent days" strip
    provides the calendar-style overview within the available height.
    Happy to switch to a graphical calendar if the popover height is made
    tab-aware.